### PR TITLE
Remove asyncio

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -30,5 +30,5 @@ setuptools.setup(
         "License :: OSI Approved :: MIT License",
         "Operating System :: OS Independent",
     ],
-    install_requires=["asyncio", "asyncio-dgram"],
+    install_requires=["asyncio-dgram"],
 )


### PR DESCRIPTION
`asyncio` is a standard module. No need to have it as a `install_requires`.

Is mainly an issue for the Fedora/CentOS RPM as it's picked-up during the build and listed as requirement. `pip` will ignore it (I assume).