### PR TITLE
Add MANIFEST.in

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,2 @@
+include LICENSE
+include README.md


### PR DESCRIPTION
Ensure that the source tarball published on PyPI contains the docs.

It's a packaging thing as most distributions require to ship the documentation files.