### PR TITLE
Add Auto-discovery support

### DIFF
--- a/pywizlight/bulb.py
+++ b/pywizlight/bulb.py
@@ -2,6 +2,7 @@
 import asyncio
 import json
 import logging
+import socket
 from time import time
 
 import asyncio_dgram
@@ -9,6 +10,7 @@ import asyncio_dgram
 from pywizlight.scenes import SCENES
 
 _LOGGER = logging.getLogger(__name__)
+FOUND_BULB_IPS = []
 
 
 class PilotBuilder:
@@ -315,3 +317,55 @@ class wizlight:
             else:
                 # exception should be created
                 raise ValueError("Cant read response from the bulb. Debug:", resp)
+
+class discovery:
+
+    class BroadcastProtocol(object):
+        """asyncio Protocol that sends a UDP broadcast message for bulb discovery."""
+
+        def __init__(self, loop):
+            self.loop = loop
+
+        def connection_made(self, transport):
+            self.transport = transport
+            sock = transport.get_extra_info("socket")
+            sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+            sock.setsockopt(socket.SOL_SOCKET, socket.SO_BROADCAST, 1)
+            self.broadcast_registration()
+
+        def broadcast_registration(self):
+            """Sends a registration method as UDP broadcast. Bulbs should respond by sending a method response"""
+            """Note: The ip and mac we give the bulb here don't seem to matter for our intents and purposes, so they're hardcoded to technically valid dummy data."""
+            register_method = """{"method":"registration","params":{"phoneMac":"AAAAAAAAAAAA","register":false,"phoneIp":"1.2.3.4","id":"1"}}"""
+            self.transport.sendto(register_method.encode(), ('255.255.255.255', 38899))
+            self.loop.call_later(1, self.broadcast_registration)
+
+        def datagram_received(self, data, addr):
+            _LOGGER.debug(
+                "received data {} from addr {} on UPD discovery port".format(
+                    data, addr
+                )
+            )
+            if """"success":true""" in data.decode():
+                ip = addr[0]
+                global FOUND_BULB_IPS
+                if ip not in FOUND_BULB_IPS:
+                    _LOGGER.debug(
+                        "Found bulb at IP: {}".format(
+                            ip
+                        )
+                    )
+                    FOUND_BULB_IPS.append(ip)
+
+        def connection_lost(self, exc):
+            _LOGGER.debug("closing udp discovery")
+
+    async def find_wizlights(self, wait_time=5):
+        loop = asyncio.get_event_loop()
+        transport, protocol = await loop.create_datagram_endpoint(
+            lambda: self.BroadcastProtocol(loop), local_addr=('0.0.0.0', 38899))
+        try:
+            await asyncio.sleep(wait_time)
+        finally:
+            transport.close()
+            return [wizlight(ip) for ip in FOUND_BULB_IPS]


### PR DESCRIPTION
This uses the UDP broadcast api documented [here](https://developer.aliyun.com/mirror/npm/package/homebridge-wiz-lan) to implement auto-discovery.

It adds a new class that sends a udp broadcast packet with a registration method(it uses dummy data since we're not actually interested in registering with the bulb, just getting its IP).

The bulbs respond to the method and we collect their IPs and then return them :) 

Sorry if the code quality isn't amazing, the last time I wrote Python was a decade ago ;) 