### PR TITLE
Update setup.py to add python_requires for ~=3.7

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -31,4 +31,5 @@ setuptools.setup(
         "Operating System :: OS Independent",
     ],
     install_requires=["asyncio-dgram"],
+    python_requires='~=3.7',
 )


### PR DESCRIPTION
We use asyncio functions that were added in 3.7, and are thus not available in earlier versions.