### PR TITLE
Add CLI tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,27 @@ loop = asyncio.get_event_loop()
 loop.run_until_complete(main())
 ```
 
+## CLI
+
+`wizlight` is a command-line tool to perform basic interactions with bulbs.
+
+```bash
+$ wizlight
+Usage: wizlight [OPTIONS] COMMAND [ARGS]...
+
+  Simple command-line tool to interact with Wizlight bulbs.
+
+Options:
+  --version  Show the version and exit.
+  --help     Show this message and exit.
+
+Commands:
+  discover  Disocver bulb in the local network.
+  off       Turn the bulb off.
+  on        Turn the bulb on.
+  state     Get the current state from the given bulb.
+```
+
 ## Discovery
 
 The discovery works with an UDP Broadcast request and collects all bulbs in the network.

--- a/pywizlight/cli.py
+++ b/pywizlight/cli.py
@@ -1,0 +1,69 @@
+"""Command-line interface to interact with dingz devices."""
+import asyncio
+from functools import wraps
+
+import click
+from pywizlight.bulb import wizlight, PilotBuilder, discovery
+
+
+def coro(f):
+    """Allow to use async in click."""
+
+    @wraps(f)
+    def wrapper(*args, **kwargs):
+        """Async wrapper."""
+        return asyncio.run(f(*args, **kwargs))
+
+    return wrapper
+
+
+@click.group()
+@click.version_option()
+def main():
+    """Simple command-line tool to interact with Wizlight bulbs."""
+
+
+@main.command("discover")
+@coro
+async def discover():
+    """Disocver bulb in the local network."""
+    click.echo("Waiting for broadcast packages...")
+
+    bulbs = await discovery.find_wizlights(discovery)
+    for bulb in bulbs:
+        click.echo(bulb.__dict__)
+
+
+@main.command("on")
+@coro
+@click.option("--ip", prompt="IP address of the bulb", help="IP address of the bulb.")
+async def turn_on(ip):
+    """Turn a given bulb on."""
+    click.echo("Turning on %s" % ip)
+    bulb = wizlight(ip)
+    await bulb.turn_on()
+
+
+@main.command("off")
+@coro
+@click.option("--ip", prompt="IP address of the bulb", help="IP address of the bulb.")
+async def turn_off(ip):
+    """Turn a given bulb off."""
+    click.echo("Turning off %s" % ip)
+    bulb = wizlight(ip)
+    await bulb.turn_off()
+
+
+@main.command("state")
+@coro
+@click.option("--ip", prompt="IP address of the bulb", help="IP address of the bulb.")
+async def state(ip):
+    """Get the current state of a given bulb."""
+    click.echo("Get the state from %s" % ip)
+    bulb = wizlight(ip)
+    state = await bulb.updateState()
+    click.echo(state.__dict__["pilotResult"])
+
+
+if __name__ == "__main__":
+    main()

--- a/setup.py
+++ b/setup.py
@@ -25,6 +25,7 @@ setuptools.setup(
     long_description_content_type="text/markdown",
     url="https://github.com/sbidy/pywizlight",
     packages=setuptools.find_packages(exclude=["test.py"]),
+    entry_points={"console_scripts": ["wizlight = pywizlight.cli:main"]},
     classifiers=[
         "Programming Language :: Python :: 3",
         "License :: OSI Approved :: MIT License",


### PR DESCRIPTION
`wizlight` is a basci CLI tool to work with the bulbs.

```bash
$ wizlight 
Usage: wizlight [OPTIONS] COMMAND [ARGS]...

  Simple command-line tool to interact with Wizlight bulbs.

Options:
  --version  Show the version and exit.
  --help     Show this message and exit.

Commands:
  discover  Disocver bulb in the local network.
  off       Turn a given bulb off.
  on        Turn a given bulb on.
  state     Get the current state of a given bulb.
```

E.g., 

```bash
$ wizlight on --ip 192.168.5.16
```
