### PR TITLE
Add license tag

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -23,6 +23,7 @@ setuptools.setup(
     description="A python connector for WiZ light bulbs (e.g SLV Play)",
     long_description=long_description,
     long_description_content_type="text/markdown",
+    license="MIT",
     url="https://github.com/sbidy/pywizlight",
     packages=setuptools.find_packages(exclude=["test.py"]),
     classifiers=[


### PR DESCRIPTION
Allows third-party tools (e.g., PyPI) to get the license details in an easy way.