### PR TITLE
bug fix: 'dimming' param is not returned in progressive scenes like w…

### DIFF
--- a/pywizlight/bulb.py
+++ b/pywizlight/bulb.py
@@ -170,7 +170,8 @@ class PilotParser:
 
     def get_brightness(self) -> int:
         """Get the value of the brightness 0-255."""
-        return self.percent_to_hex(self.pilotResult["dimming"])
+        if 'dimming' in self.pilotResult:
+            return self.percent_to_hex(self.pilotResult['dimming'])
 
     def get_colortemp(self) -> int:
         """Get the color temperatur from the bulb."""


### PR DESCRIPTION
…ake-up

I had overlooked this earlier. This seems to be an issue since the beginning. If your rhythm has a 'wake-up' scene or if you set your light to 'wake-up' or any of the 'progressive scenes', i.e. 'wake-up' or 'bedtime', then the 'dimming' param is not returned by the lights in getPilot :)

this causes an exception in pywizlight, thus causing the light to become unavailable:
```
2020-12-21 19:43:46 ERROR (MainThread) [homeassistant.helpers.entity] Update for light.living_room_lamp_3_wiz_a55ec9 fails
Traceback (most recent call last):
  File "/usr/src/homeassistant/homeassistant/helpers/entity.py", line 278, in async_update_ha_state
    await self.async_device_update()
  File "/usr/src/homeassistant/homeassistant/helpers/entity.py", line 474, in async_device_update
    raise exc
  File "/config/custom_components/wiz_light/light.py", line 211, in async_update
    self.update_brightness()
  File "/config/custom_components/wiz_light/light.py", line 245, in update_brightness
    if self._light.state.get_brightness() is None:
  File "/config/custom_components/wiz_light/wizlight.py", line 197, in get_brightness
    return self.percent_to_hex(self.pilotResult['dimming'])
KeyError: 'dimming'
```
this small fix fixes this