### PR TITLE
Add support for ESP15_SHRGB1S_01I

### DIFF
--- a/pywizlight/bulblibrary.py
+++ b/pywizlight/bulblibrary.py
@@ -157,6 +157,13 @@ class BulbLib:
             features=Features(brightness=True, color=True, effect=True, color_tmp=True),
             kelvin_range=KelvinRange(min=2200, max=6500),
         ),
+        BulbType(
+			name="ESP15_SHRGB1S_01I",
+			features=Features(
+				brightness=True, color=True, effect=True, color_tmp=True
+			),
+			kelvin_range=KelvinRange(min=2200, max=6500),
+		),
     ]
 
     def getBulbList(self) -> list:

--- a/pywizlight/bulblibrary.py
+++ b/pywizlight/bulblibrary.py
@@ -158,12 +158,10 @@ class BulbLib:
             kelvin_range=KelvinRange(min=2200, max=6500),
         ),
         BulbType(
-			name="ESP15_SHRGB1S_01I",
-			features=Features(
-				brightness=True, color=True, effect=True, color_tmp=True
-			),
-			kelvin_range=KelvinRange(min=2200, max=6500),
-		),
+            name="ESP15_SHRGB1S_01I",
+            features=Features(brightness=True, color=True, effect=True, color_tmp=True),
+            kelvin_range=KelvinRange(min=2200, max=6500),
+        ),
     ]
 
     def getBulbList(self) -> list:


### PR DESCRIPTION
Hey,

this PR is related to bulb: https://www.amazon.de/gp/product/B07YLW52MK


## Error

I got the exception using `get_bulbtype()`:

```
raise WizLightNotKnownBulb("The bulb is unknown to the intergration.")
```

## Config

So I debugged it using `getBulbConfig` and got the following config:

```
{
  'method': 'getSystemConfig',
  'env': 'pro',
  'result': {
    'mac': 'xxx',
    'homeId': 12345,
    'roomId': 12345,
    'moduleName': 'ESP15_SHRGB1S_01I',
    'fwVersion': '1.21.0',
    'groupId': 0,
    'drvConf': [
      36,
      1
    ],
    'ewf': [
      200,
      255,
      255,
      255,
      0,
      0,
      0
    ],
    'ewfHex': 'c8ffffff000000',
    'ping': 0
  }
}
```

Therfore extending the `BULBLIST``with the entry of this pull request solved the issue for me.