### PR TITLE
Fix `wizlight discovery`

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ async def main():
     """Sample code to work with bulbs."""
     # Discover all bulbs in the network via broadcast datagram (UDP)
     # function takes the discovery object and returns a list with wizlight objects.
-    bulbs = await discovery.find_wizlights(discovery)
+    bulbs = await discovery.find_wizlights()
     # Print the IP address of the bulb on index 0
     print(f"Bulb IP address: {bulbs[0].ip}")
 

--- a/pywizlight/cli.py
+++ b/pywizlight/cli.py
@@ -30,7 +30,7 @@ async def discover():
     """Disocver bulb in the local network."""
     click.echo("Waiting for broadcast packages...")
 
-    bulbs = await discovery.find_wizlights(discovery)
+    bulbs = await discovery.find_wizlights()
     for bulb in bulbs:
         click.echo(bulb.__dict__)
 


### PR DESCRIPTION
`wizlight discovery` is not working in 0.4.2, this fixes it.

- discovery.find_wizlights() no longer takes discovery as an arg
- so it was being passed as wait_time
- which resulting in a call to asyncio.sleep(discovery), which failed because discovery is a module, not a number of seconds