### PR TITLE
Added ESP01_SHRGB3_01 (WiZ Hero) to bulb library

### DIFF
--- a/pywizlight/bulblibrary.py
+++ b/pywizlight/bulblibrary.py
@@ -138,6 +138,11 @@ class BulbLib:
             features=Features(brightness=True, color=True, effect=True, color_tmp=True),
             kelvin_range=KelvinRange(min=2200, max=6500),
         ),
+        BulbType(
+            name="ESP01_SHRGB3_01",
+            features=Features(brightness=True, color=True, effect=True, color_tmp=True),
+            kelvin_range=KelvinRange(min=2200, max=6500),
+        ),
         # Test device
         BulbType(
             name="ESP01_SHRGB_03",


### PR DESCRIPTION
Hi, I recently purchased two [WiZ hero](https://www.wizconnected.com/en/consumer/products/8719514261280/) standalone desk lamps and but they were not supported in pywizlight. They have the same features and interface as the full featured E27 bulbs. I added it to the bulb library and they became detected and worked perfectly (tested as part of the [WiZ Home Assistant integration](https://github.com/sbidy/wiz_light)).

Output of the `getSystemConfig ` JSON RPC command:
`pi@raspberrypi:~ $ echo '{"method":"getSystemConfig","params":{}}' | nc -u -w 1 192.168.1.233 38899
{"method":"getSystemConfig","env":"pro","result":{"mac":"a8bb50230801","homeId":2566123,"roomId":3880771,"moduleName":"ESP01_SHRGB3_01","fwVersion":"1.21.2","groupId":0,"drvConf":[20,2],"ewf":[200,255,150,255,0,0,40],"ewfHex":"c8ff96ff000028","ping":0}}`

Please let me know if this change can be incorporated into the main code base.
Cheers, Durnezj