### PR TITLE
Fix typo, linter

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ loop.run_until_complete(main())
 
 `wizlight` is a command-line tool to perform basic interactions with bulbs.
 
-```bash
+```console
 $ wizlight
 Usage: wizlight [OPTIONS] COMMAND [ARGS]...
 
@@ -164,7 +164,7 @@ Options:
   --help     Show this message and exit.
 
 Commands:
-  discover  Disocver bulb in the local network.
+  discover  Discover bulb in the local network.
   off       Turn the bulb off.
   on        Turn the bulb on.
   state     Get the current state from the given bulb.


### PR DESCRIPTION
Sorry for the trivial PR.

Changed the linter used for the CLI example from `bash` to `console`, so bash keywords are not highlighted. 
Fixed a typo.