### PR TITLE
Add support for discovering new devices via broadcast of their first heartbeat

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -3,3 +3,5 @@ source = pywizlight
 
 omit =
      pywizlight/tests/*
+     pywizlight/_version.py
+     pywizlight/cli.py

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -27,7 +27,7 @@ jobs:
           python-version: 3.8
 
       - name: Install Python dependencies
-        run: pip install black flake8 mypy pytest pytest-cov -e .
+        run: pip install black flake8 mypy pytest pytest-cov pytest-asyncio -e .
 
       - name: Run linters
         uses: samuelmeuli/lint-action@v1

--- a/pywizlight/bulblibrary.py
+++ b/pywizlight/bulblibrary.py
@@ -12,7 +12,7 @@ RGB -- Fullstack bulb
 """
 import dataclasses
 from enum import Enum
-from typing import Optional, List
+from typing import List, Optional
 
 from pywizlight.exceptions import WizLightNotKnownBulb
 
@@ -71,10 +71,16 @@ class BulbType:
     kelvin_range: Optional[KelvinRange]
     bulb_type: BulbClass
     fw_version: Optional[str]
+    white_channels: Optional[int]
+    white_to_color_ratio: Optional[int]
 
     @staticmethod
     def from_data(
-        module_name: str, kelvin_list: Optional[List[float]], fw_version: Optional[str]
+        module_name: str,
+        kelvin_list: Optional[List[float]],
+        fw_version: Optional[str],
+        white_channels: Optional[int],
+        white_to_color_ratio: Optional[int],
     ) -> "BulbType":
         if kelvin_list:
             kelvin_range: Optional[KelvinRange] = KelvinRange(
@@ -107,4 +113,6 @@ class BulbType:
             features=features,
             kelvin_range=kelvin_range,
             fw_version=fw_version,
+            white_channels=white_channels,
+            white_to_color_ratio=white_to_color_ratio,
         )

--- a/pywizlight/cli.py
+++ b/pywizlight/cli.py
@@ -1,7 +1,7 @@
 """Command-line interface to interact with wizlight devices."""
 import asyncio
 from functools import wraps
-from typing import Callable, Any, TypeVar, Coroutine
+from typing import Any, Callable, Coroutine, TypeVar
 
 import click
 

--- a/pywizlight/discovery.py
+++ b/pywizlight/discovery.py
@@ -1,12 +1,12 @@
 """Discover bulbs in a network."""
 import asyncio
-import dataclasses
 import json
 import logging
-from asyncio import DatagramTransport, BaseTransport, AbstractEventLoop, Future
-from typing import cast, Dict, List, Tuple, Optional, Any
+from asyncio import AbstractEventLoop, BaseTransport, DatagramTransport, Future
+from typing import Any, List, Optional, Tuple, cast
 
 from pywizlight import wizlight
+from pywizlight.models import BulbRegistry, DiscoveredBulb
 from pywizlight.utils import create_udp_broadcast_socket
 
 _LOGGER = logging.getLogger(__name__)
@@ -18,29 +18,6 @@ DEFAULT_WAIT_TIME = 5.0
 # we have register set to false which is telling the bulb to remove
 # the registration
 REGISTER_MESSAGE = b'{"method":"registration","params":{"phoneMac":"AAAAAAAAAAAA","register":false,"phoneIp":"1.2.3.4","id":"1"}}'  # noqa: E501
-
-
-@dataclasses.dataclass(frozen=True)
-class DiscoveredBulb:
-    """Representation of discovered bulb."""
-
-    ip_address: str
-    mac_address: str
-
-
-@dataclasses.dataclass
-class BulbRegistry:
-    """Representation of the bulb registry."""
-
-    bulbs_by_mac: Dict[str, DiscoveredBulb] = dataclasses.field(default_factory=dict)
-
-    def register(self, bulb: DiscoveredBulb) -> None:
-        """Register a new bulb."""
-        self.bulbs_by_mac[bulb.mac_address] = bulb
-
-    def bulbs(self) -> List[DiscoveredBulb]:
-        """Get all present bulbs."""
-        return list(self.bulbs_by_mac.values())
 
 
 class BroadcastProtocol(asyncio.DatagramProtocol):
@@ -69,7 +46,7 @@ class BroadcastProtocol(asyncio.DatagramProtocol):
         """Send a registration method as UDP broadcast."""
         if not self.transport:
             return
-        self.transport.sendto(REGISTER_MESSAGE, (self.broadcast_address, 38899))
+        self.transport.sendto(REGISTER_MESSAGE, (self.broadcast_address, PORT))
         self.loop.call_later(1, self.broadcast_registration)
 
     def datagram_received(self, data: bytes, addr: Tuple[str, int]) -> None:

--- a/pywizlight/models.py
+++ b/pywizlight/models.py
@@ -1,0 +1,26 @@
+"""Models."""
+import dataclasses
+from typing import Dict, List
+
+
+@dataclasses.dataclass(frozen=True)
+class DiscoveredBulb:
+    """Representation of discovered bulb."""
+
+    ip_address: str
+    mac_address: str
+
+
+@dataclasses.dataclass
+class BulbRegistry:
+    """Representation of the bulb registry."""
+
+    bulbs_by_mac: Dict[str, DiscoveredBulb] = dataclasses.field(default_factory=dict)
+
+    def register(self, bulb: DiscoveredBulb) -> None:
+        """Register a new bulb."""
+        self.bulbs_by_mac[bulb.mac_address] = bulb
+
+    def bulbs(self) -> List[DiscoveredBulb]:
+        """Get all present bulbs."""
+        return list(self.bulbs_by_mac.values())

--- a/pywizlight/rgbcw.py
+++ b/pywizlight/rgbcw.py
@@ -1,9 +1,11 @@
 """Manages the RGBCW color."""
 import logging
 from math import atan2, cos, pi
-from typing import Tuple, Iterable
+from typing import Iterable, Tuple
 
 from .vec import (
+    EPSILON,
+    Vector,
     vecAdd,
     vecDot,
     vecFormat,
@@ -11,8 +13,6 @@ from .vec import (
     vecInt,
     vecLen,
     vecMul,
-    EPSILON,
-    Vector,
 )
 
 _LOGGER = logging.getLogger(__name__)

--- a/pywizlight/scenes.py
+++ b/pywizlight/scenes.py
@@ -1,4 +1,9 @@
 """Definition of the supported bulb effects."""
+
+from typing import Dict, Iterable, List, cast
+
+from pywizlight.bulblibrary import BulbClass
+
 SCENES = {
     1: "Ocean",
     2: "Romance",
@@ -35,6 +40,14 @@ SCENES = {
     1000: "Rhythm",
 }
 SCENE_NAME_TO_ID = {scene_name: scene_id for (scene_id, scene_name) in SCENES.items()}
+TW_SCENES = [6, 9, 10, 11, 12, 13, 14, 15, 16, 18, 29, 30, 31, 32]
+DW_SCENES = [9, 10, 13, 14, 29, 30, 31, 32]
+
+SCENES_BY_CLASS: Dict[BulbClass, List[str]] = {
+    BulbClass.RGB: list(cast(Iterable, SCENES)),
+    BulbClass.TW: [SCENES[key] for key in TW_SCENES],
+    BulbClass.DW: [SCENES[key] for key in DW_SCENES],
+}
 
 
 def get_id_from_scene_name(scene: str) -> int:

--- a/pywizlight/tests/fake_bulb.py
+++ b/pywizlight/tests/fake_bulb.py
@@ -4,6 +4,46 @@ import socketserver
 import threading
 from typing import Any, Callable, Dict
 
+MODULE_CONFIGS = {
+    "ESP01_SHRGB_03": {
+        "ps": 1,
+        "pwmFreq": 1000,
+        "pwmRange": [3, 100],
+        "wcr": 30,
+        "nowc": 1,
+        "cctRange": [2200, 2700, 4800, 6500],
+        "renderFactor": [171, 255, 75, 255, 43, 85, 0, 0, 0, 0],
+    },
+    "ESP10_SOCKET_06": {
+        "ps": 1,
+        "pwmFreq": 200,
+        "pwmRange": [1, 100],
+        "wcr": 20,
+        "nowc": 2,
+        "cctRange": [2700, 2700, 2700, 2700],
+        "renderFactor": [255, 0, 255, 255, 0, 0, 0, 0, 0, 0],
+    },
+    "ESP05_SHDW_21": {
+        "ps": 1,
+        "pwmFreq": 1000,
+        "pwmRange": [5, 100],
+        "wcr": 20,
+        "nowc": 1,
+        "cctRange": [2700, 2700, 2700, 2700],
+        "renderFactor": [255, 0, 255, 255, 0, 0, 0, 0, 0, 0],
+    },
+    "ESP20_SHRGB_01ABI": {
+        "ps": 0,
+        "pwmFreq": 2000,
+        "pwmRange": [5, 100],
+        "wcr": 80,
+        "nowc": 2,
+        "cctRange": [2700, 2700, 6500, 6500],
+        "renderFactor": [255, 0, 255, 255, 0, 0, 0, 81, 245, 178],
+        "drvIface": 0,
+    },
+}
+
 
 def get_initial_pilot() -> Dict[str, Any]:
     return {
@@ -45,19 +85,11 @@ def get_initial_sys_config() -> Dict[str, Any]:
     }
 
 
-def get_initial_model_config() -> Dict[str, Any]:
+def get_initial_model_config(module_name: str) -> Dict[str, Any]:
     return {
         "method": "getModelConfig",
         "env": "pro",
-        "result": {
-            "ps": 1,
-            "pwmFreq": 1000,
-            "pwmRange": [3, 100],
-            "wcr": 30,
-            "nowc": 1,
-            "cctRange": [2200, 2700, 4800, 6500],
-            "renderFactor": [171, 255, 75, 255, 43, 85, 0, 0, 0, 0],
-        },
+        "result": MODULE_CONFIGS[module_name],
     }
 
 
@@ -106,7 +138,7 @@ def make_udp_fake_bulb_server(module_name: str) -> socketserver.ThreadingUDPServ
     """Configure a fake bulb instance."""
     pilot_state = get_initial_pilot()
     sys_config = get_initial_sys_config()
-    model_config = get_initial_model_config()
+    model_config = get_initial_model_config(module_name)
     sys_config["result"]["moduleName"] = module_name
 
     BulbUDPRequestHandler = type(

--- a/pywizlight/tests/test_bulb_dimmable_white.py
+++ b/pywizlight/tests/test_bulb_dimmable_white.py
@@ -1,0 +1,32 @@
+"""Tests for the Bulb API with a light strip."""
+from typing import AsyncGenerator
+
+import pytest
+
+from pywizlight import wizlight
+from pywizlight.bulblibrary import BulbClass, BulbType, Features, KelvinRange
+from pywizlight.tests.fake_bulb import startup_bulb
+
+
+@pytest.fixture()
+async def dimmable_bulb() -> AsyncGenerator[wizlight, None]:
+    shutdown = startup_bulb(module_name="ESP05_SHDW_21")
+    bulb = wizlight(ip="127.0.0.1")
+    yield bulb
+    await bulb.async_close()
+    shutdown()
+
+
+@pytest.mark.asyncio
+async def test_model_description_dimmable_bulb(dimmable_bulb: wizlight) -> None:
+    """Test fetching the model description dimmable bulb."""
+    bulb_type = await dimmable_bulb.get_bulbtype()
+    assert bulb_type == BulbType(
+        features=Features(color=False, color_tmp=False, effect=False, brightness=True),
+        name="ESP05_SHDW_21",
+        kelvin_range=KelvinRange(max=2700, min=2700),
+        bulb_type=BulbClass.DW,
+        fw_version="1.21.0",
+        white_channels=1,
+        white_to_color_ratio=20,
+    )

--- a/pywizlight/tests/test_bulb_light_strip.py
+++ b/pywizlight/tests/test_bulb_light_strip.py
@@ -1,0 +1,32 @@
+"""Tests for the Bulb API with a light strip."""
+from typing import AsyncGenerator
+
+import pytest
+
+from pywizlight import wizlight
+from pywizlight.bulblibrary import BulbClass, BulbType, Features, KelvinRange
+from pywizlight.tests.fake_bulb import startup_bulb
+
+
+@pytest.fixture()
+async def light_strip() -> AsyncGenerator[wizlight, None]:
+    shutdown = startup_bulb(module_name="ESP20_SHRGB_01ABI")
+    bulb = wizlight(ip="127.0.0.1")
+    yield bulb
+    await bulb.async_close()
+    shutdown()
+
+
+@pytest.mark.asyncio
+async def test_model_description_light_strip(light_strip: wizlight) -> None:
+    """Test fetching the model description for a light strip."""
+    bulb_type = await light_strip.get_bulbtype()
+    assert bulb_type == BulbType(
+        features=Features(color=True, color_tmp=True, effect=True, brightness=True),
+        name="ESP20_SHRGB_01ABI",
+        kelvin_range=KelvinRange(max=6500, min=2700),
+        bulb_type=BulbClass.RGB,
+        fw_version="1.21.0",
+        white_channels=2,
+        white_to_color_ratio=80,
+    )

--- a/pywizlight/tests/test_bulb_socket.py
+++ b/pywizlight/tests/test_bulb_socket.py
@@ -1,0 +1,32 @@
+"""Tests for the Bulb API with a socket."""
+from typing import AsyncGenerator
+
+import pytest
+
+from pywizlight import wizlight
+from pywizlight.bulblibrary import BulbClass, BulbType, Features, KelvinRange
+from pywizlight.tests.fake_bulb import startup_bulb
+
+
+@pytest.fixture()
+async def socket() -> AsyncGenerator[wizlight, None]:
+    shutdown = startup_bulb(module_name="ESP10_SOCKET_06")
+    bulb = wizlight(ip="127.0.0.1")
+    yield bulb
+    await bulb.async_close()
+    shutdown()
+
+
+@pytest.mark.asyncio
+async def test_model_description_socket(socket: wizlight) -> None:
+    """Test fetching the model description of a socket is None."""
+    bulb_type = await socket.get_bulbtype()
+    assert bulb_type == BulbType(
+        features=Features(color=False, color_tmp=False, effect=False, brightness=False),
+        name="ESP10_SOCKET_06",
+        kelvin_range=KelvinRange(max=2700, min=2700),
+        bulb_type=BulbClass.SOCKET,
+        fw_version="1.21.0",
+        white_channels=2,
+        white_to_color_ratio=20,
+    )

--- a/pywizlight/tests/test_scenes.py
+++ b/pywizlight/tests/test_scenes.py
@@ -1,0 +1,14 @@
+"""Tests for the Scenes."""
+
+
+import pytest
+
+from pywizlight import scenes
+
+
+@pytest.mark.asyncio
+async def test_get_id_from_scene_name() -> None:
+    """Test looking up a scene id from the name."""
+    with pytest.raises(ValueError):
+        scenes.get_id_from_scene_name("non_exist")
+    assert scenes.get_id_from_scene_name("Ocean") == 1

--- a/pywizlight/tests/test_utils.py
+++ b/pywizlight/tests/test_utils.py
@@ -1,0 +1,18 @@
+"""Tests for the Utils."""
+
+
+import pytest
+
+from pywizlight import utils
+
+
+@pytest.mark.asyncio
+async def test_generate_mac() -> None:
+    """Test generating a mac address."""
+    assert len(utils.generate_mac()) == 12
+
+
+@pytest.mark.asyncio
+async def test_get_source_ip() -> None:
+    """Test we can get the source ip for loopback."""
+    assert utils.get_source_ip("127.0.0.1") == "127.0.0.1"

--- a/pywizlight/utils.py
+++ b/pywizlight/utils.py
@@ -1,5 +1,10 @@
 import json
+import logging
+import random
 import socket
+from typing import Optional, cast
+
+_LOGGER = logging.getLogger(__name__)
 
 
 def hex_to_percent(hex_value: float) -> float:
@@ -19,17 +24,47 @@ def to_wiz_json(dump_obj):
 
 def create_udp_broadcast_socket(listen_port: int) -> socket.socket:
     """Create a udp broadcast socket used for communicating with the device."""
-    sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
-    sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
-    sock.setsockopt(socket.SOL_SOCKET, socket.SO_BROADCAST, 1)
-    sock.bind(("", listen_port))
-    sock.setblocking(False)
-    return sock
+    return _create_udp_socket(listen_port, reuseaddr=True, broadcast=True)
 
 
 def create_udp_socket(listen_port: int) -> socket.socket:
     """Create a udp socket used for communicating with the device."""
+    return _create_udp_socket(listen_port, reuseaddr=False, broadcast=False)
+
+
+def _create_udp_socket(
+    listen_port: int, reuseaddr: bool = False, broadcast: bool = False
+) -> socket.socket:
+    """Create a udp socket used for communicating with the device."""
     sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+    if reuseaddr:
+        sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+    if broadcast:
+        sock.setsockopt(socket.SOL_SOCKET, socket.SO_BROADCAST, 1)
     sock.bind(("", listen_port))
     sock.setblocking(False)
     return sock
+
+
+def generate_mac():
+    """Generates a fake mac address."""
+    return "{}{}{}{}{}{}{}{}{}{}{}{}".format(
+        *(random.SystemRandom().choice("0123456789abcdef") for _ in range(12))
+    )
+
+
+def get_source_ip(target_ip: str) -> Optional[str]:
+    """Return the source ip that will reach target_ip."""
+    test_sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+    test_sock.setblocking(False)  # must be non-blocking for async
+    try:
+        test_sock.connect((target_ip, 1))
+        return cast(str, test_sock.getsockname()[0])
+    except Exception:  # pylint: disable=broad-except
+        _LOGGER.debug(
+            "The system could not auto detect the source ip for %s on your operating system",
+            target_ip,
+        )
+        return None
+    finally:
+        test_sock.close()

--- a/pywizlight/vec.py
+++ b/pywizlight/vec.py
@@ -2,8 +2,8 @@
 
     A bunch of utility functions, just so we don't have to bring in any external dependencies.
 """
-from math import sqrt, sin, cos
-from operator import mul, sub, add
+from math import cos, sin, sqrt
+from operator import add, mul, sub
 from typing import Tuple
 
 # a small value, really close to zero, more than adequate for our 3 orders of magnitude


### PR DESCRIPTION
- Adds `set_discovery_callback` which will immediately discover devices when they boot up when push updates are active.    
  Devices broadcast a `firstBeat` udp packet on boot with their mac address which allows us to discover new devices, and update the ip address we have for the device to avoid having to wait for the next discovery.

- Adds white channels and white to color ratio from bulb config.  The data described in #77 seems to be a lot more generic and its actually the number of white channels and white to color ratio. 
Closes #77

- Various refactoring and tests to increase test coverage

- Remove `connect_on_init` as it did blocking I/O which would stall the event loop
