### PR TITLE
Fix reporting available scenes on RGB devices

### DIFF
--- a/pywizlight/bulb.py
+++ b/pywizlight/bulb.py
@@ -6,6 +6,8 @@ import logging
 import time
 from typing import Any, Callable, Dict, List, Optional, Tuple, Union, cast
 
+from pywizlight.exceptions import WizLightNotKnownBulb
+
 from pywizlight.bulblibrary import BulbType
 from pywizlight.exceptions import (
     WizLightConnectionError,
@@ -453,7 +455,9 @@ class wizlight:
         bulb_config = await self.getBulbConfig()
         result = bulb_config["result"]
         if "moduleName" not in result:
-            raise ValueError("Unable to determine bulb type.")
+            raise WizLightNotKnownBulb(
+                "Unable to determine the bulb type; moduleName is missing from getSystemConfig"
+            )
         white_range = await self.getExtendedWhiteRange()
         white_to_color_ratio = None
         white_channels = None

--- a/pywizlight/bulblibrary.py
+++ b/pywizlight/bulblibrary.py
@@ -82,19 +82,14 @@ class BulbType:
         white_channels: Optional[int],
         white_to_color_ratio: Optional[int],
     ) -> "BulbType":
-        if kelvin_list:
-            kelvin_range: Optional[KelvinRange] = KelvinRange(
-                min=int(min(kelvin_list)), max=int(max(kelvin_list))
-            )
-        else:
-            kelvin_range = None
-
         try:
             # parse the features from name
             _identifier = module_name.split("_")[1]
         # Throw exception if index can not be found
         except IndexError:
-            raise WizLightNotKnownBulb("The bulb type can not be determined!")
+            raise WizLightNotKnownBulb(
+                f"The bulb type could not be determined from the module name: {module_name}"
+            )
 
         if "RGB" in _identifier:  # full RGB bulb
             bulb_type = BulbClass.RGB
@@ -104,6 +99,17 @@ class BulbType:
             bulb_type = BulbClass.SOCKET
         else:  # Plain brightness-only bulb
             bulb_type = BulbClass.DW
+
+        if kelvin_list:
+            kelvin_range: Optional[KelvinRange] = KelvinRange(
+                min=int(min(kelvin_list)), max=int(max(kelvin_list))
+            )
+        elif bulb_type in (BulbClass.RGB, BulbClass.TW):
+            raise WizLightNotKnownBulb(
+                f"Unable to determine required kelvin range for a {bulb_type.value} device"
+            )
+        else:
+            kelvin_range = None
 
         features = FEATURE_MAP[bulb_type]
 

--- a/pywizlight/scenes.py
+++ b/pywizlight/scenes.py
@@ -44,7 +44,7 @@ TW_SCENES = [6, 9, 10, 11, 12, 13, 14, 15, 16, 18, 29, 30, 31, 32]
 DW_SCENES = [9, 10, 13, 14, 29, 30, 31, 32]
 
 SCENES_BY_CLASS: Dict[BulbClass, List[str]] = {
-    BulbClass.RGB: list(cast(Iterable, SCENES)),
+    BulbClass.RGB: list(cast(Iterable, SCENES.values())),
     BulbClass.TW: [SCENES[key] for key in TW_SCENES],
     BulbClass.DW: [SCENES[key] for key in DW_SCENES],
 }

--- a/pywizlight/tests/fake_bulb.py
+++ b/pywizlight/tests/fake_bulb.py
@@ -72,6 +72,47 @@ MODULE_CONFIGS = {
             "drvIface": 0,
         },
     },
+    ("MISSING", "1.16.64"): {
+        "method": "getModelConfig",
+        "env": "pro",
+        "result": {
+            "ps": 2,
+            "pwmFreq": 5000,
+            "pwmRange": [1, 100],
+            "wcr": 20,
+            "nowc": 1,
+            "cctRange": [2700, 2700, 5000, 5000],
+            "renderFactor": [255, 0, 255, 255, 0, 0, 0, 0, 0, 0],
+            "drvIface": 0,
+        },
+    },
+    ("MISSING_KELVIN", "1.16.64"): {
+        "method": "getModelConfig",
+        "env": "pro",
+        "result": {
+            "ps": 2,
+            "pwmFreq": 5000,
+            "pwmRange": [1, 100],
+            "wcr": 20,
+            "nowc": 1,
+            "renderFactor": [255, 0, 255, 255, 0, 0, 0, 0, 0, 0],
+            "drvIface": 0,
+        },
+    },
+    ("INVALID", "1.16.64"): {
+        "method": "getModelConfig",
+        "env": "pro",
+        "result": {
+            "ps": 2,
+            "pwmFreq": 5000,
+            "pwmRange": [1, 100],
+            "wcr": 20,
+            "nowc": 1,
+            "cctRange": [2700, 2700, 5000, 5000],
+            "renderFactor": [255, 0, 255, 255, 0, 0, 0, 0, 0, 0],
+            "drvIface": 0,
+        },
+    },
 }
 
 SYSTEM_CONFIGS = {
@@ -82,7 +123,7 @@ SYSTEM_CONFIGS = {
             "mac": "a8bb5006033d",
             "homeId": 653906,
             "roomId": 989983,
-            "moduleName": "",
+            "moduleName": "ESP01_SHRGB_03",
             "fwVersion": "1.25.0",
             "groupId": 0,
             "drvConf": [30, 1],
@@ -98,7 +139,7 @@ SYSTEM_CONFIGS = {
             "mac": "a8bb5006033d",
             "homeId": 653906,
             "roomId": 989983,
-            "moduleName": "",
+            "moduleName": "ESP10_SOCKET_06",
             "fwVersion": "1.25.0",
             "groupId": 0,
             "drvConf": [20, 2],
@@ -114,7 +155,7 @@ SYSTEM_CONFIGS = {
             "mac": "a8bb5006033d",
             "homeId": 653906,
             "roomId": 989983,
-            "moduleName": "",
+            "moduleName": "ESP05_SHDW_21",
             "fwVersion": "1.25.0",
             "groupId": 0,
             "drvConf": [20, 1],
@@ -130,7 +171,7 @@ SYSTEM_CONFIGS = {
             "mac": "a8bb5006033d",
             "homeId": 653906,
             "roomId": 989983,
-            "moduleName": "",
+            "moduleName": "ESP20_SHRGB_01ABI",
             "fwVersion": "1.25.0",
             "groupId": 0,
             "drvConf": [80, 2],
@@ -146,7 +187,7 @@ SYSTEM_CONFIGS = {
             "mac": "a8bb5006033d",
             "homeId": 653906,
             "roomId": 989983,
-            "moduleName": "",
+            "moduleName": "ESP20_SHRGB_01ABI",
             "fwVersion": "1.21.4",
             "groupId": 0,
             "drvConf": [80, 2],
@@ -196,6 +237,47 @@ SYSTEM_CONFIGS = {
             "roomId": 8016844,
             "rgn": "eu",
             "moduleName": "ESP21_SHTW_01",
+            "fwVersion": "1.25.0",
+            "groupId": 0,
+            "ping": 0,
+        },
+    },
+    ("MISSING_KELVIN", "1.16.64"): {
+        "method": "getSystemConfig",
+        "env": "pro",
+        "result": {
+            "mac": "6c29905a067c",
+            "homeId": 5385975,
+            "roomId": 8016844,
+            "rgn": "eu",
+            "moduleName": "ESP21_SHTW_01",
+            "fwVersion": "1.25.0",
+            "groupId": 0,
+            "ping": 0,
+        },
+    },
+    ("MISSING", "1.16.64"): {
+        "method": "getSystemConfig",
+        "env": "pro",
+        "result": {
+            "mac": "6c29905a067c",
+            "homeId": 5385975,
+            "roomId": 8016844,
+            "rgn": "eu",
+            "fwVersion": "1.25.0",
+            "groupId": 0,
+            "ping": 0,
+        },
+    },
+    ("INVALID", "1.16.64"): {
+        "method": "getSystemConfig",
+        "env": "pro",
+        "result": {
+            "mac": "6c29905a067c",
+            "homeId": 5385975,
+            "roomId": 8016844,
+            "rgn": "eu",
+            "moduleName": "INVALID",
             "fwVersion": "1.25.0",
             "groupId": 0,
             "ping": 0,
@@ -349,7 +431,6 @@ def make_udp_fake_bulb_server(
     sys_config = get_initial_sys_config(module_name, firmware_version)
     model_config = get_initial_model_config(module_name, firmware_version)
     user_config = get_initial_user_config(module_name, firmware_version)
-    sys_config["result"]["moduleName"] = module_name
 
     BulbUDPRequestHandler = type(
         "BulbUDPRequestHandler",

--- a/pywizlight/tests/fake_bulb.py
+++ b/pywizlight/tests/fake_bulb.py
@@ -58,6 +58,20 @@ MODULE_CONFIGS = {
             "drvIface": 0,
         },
     },
+    ("ESP21_SHTW_01", "1.25.0"): {
+        "method": "getModelConfig",
+        "env": "pro",
+        "result": {
+            "ps": 2,
+            "pwmFreq": 5000,
+            "pwmRange": [1, 100],
+            "wcr": 20,
+            "nowc": 1,
+            "cctRange": [2700, 2700, 5000, 5000],
+            "renderFactor": [255, 0, 255, 255, 0, 0, 0, 0, 0, 0],
+            "drvIface": 0,
+        },
+    },
 }
 
 SYSTEM_CONFIGS = {
@@ -157,6 +171,36 @@ SYSTEM_CONFIGS = {
             "drvConf": [20, 1],
         },
     },
+    ("ESP20_SHRGBC_01", "1.21.4"): {
+        "method": "getSystemConfig",
+        "env": "pro",
+        "result": {
+            "mac": "6c2990e493bc",
+            "homeId": 5385975,
+            "roomId": 8016844,
+            "moduleName": "ESP20_SHRGBC_01",
+            "fwVersion": "1.21.4",
+            "groupId": 0,
+            "drvConf": [30, 1],
+            "ewf": [200, 255, 150, 255, 0, 0, 40],
+            "ewfHex": "c8ff96ff000028",
+            "ping": 0,
+        },
+    },
+    ("ESP21_SHTW_01", "1.25.0"): {
+        "method": "getSystemConfig",
+        "env": "pro",
+        "result": {
+            "mac": "6c29905a067c",
+            "homeId": 5385975,
+            "roomId": 8016844,
+            "rgn": "eu",
+            "moduleName": "ESP21_SHTW_01",
+            "fwVersion": "1.25.0",
+            "groupId": 0,
+            "ping": 0,
+        },
+    },
 }
 
 USER_CONFIGS = {
@@ -187,6 +231,20 @@ USER_CONFIGS = {
             "extRange": [2700, 6500],
             "opMode": 0,
             "po": False,
+        },
+    },
+    ("ESP20_SHRGBC_01", "1.21.4"): {
+        "method": "getUserConfig",
+        "env": "pro",
+        "result": {
+            "fadeIn": 500,
+            "fadeOut": 500,
+            "dftDim": 100,
+            "pwmRange": [0, 100],
+            "whiteRange": [2700, 6500],
+            "extRange": [2200, 6500],
+            "opMode": 0,
+            "po": True,
         },
     },
 }

--- a/pywizlight/tests/test_bulb_invalid_module_name.py
+++ b/pywizlight/tests/test_bulb_invalid_module_name.py
@@ -1,0 +1,24 @@
+"""Tests for the Bulb API with a light strip."""
+from typing import AsyncGenerator
+
+import pytest
+
+from pywizlight import wizlight
+from pywizlight.tests.fake_bulb import startup_bulb
+from pywizlight.exceptions import WizLightNotKnownBulb
+
+
+@pytest.fixture()
+async def no_module_bulb() -> AsyncGenerator[wizlight, None]:
+    shutdown = startup_bulb(module_name="MISSING", firmware_version="1.16.64")
+    bulb = wizlight(ip="127.0.0.1")
+    yield bulb
+    await bulb.async_close()
+    shutdown()
+
+
+@pytest.mark.asyncio
+async def test_model_description_no_module_bulb(no_module_bulb: wizlight) -> None:
+    """Test fetching the model description for a bulb missing the module."""
+    with pytest.raises(WizLightNotKnownBulb):
+        await no_module_bulb.get_bulbtype()

--- a/pywizlight/tests/test_bulb_light_strip_1_25_0.py
+++ b/pywizlight/tests/test_bulb_light_strip_1_25_0.py
@@ -26,6 +26,46 @@ async def test_setting_rgbww(light_strip: wizlight) -> None:
 
 
 @pytest.mark.asyncio
+async def test_supported_scenes(light_strip: wizlight) -> None:
+    """Test supported scenes."""
+    assert await light_strip.getSupportedScenes() == [
+        "Ocean",
+        "Romance",
+        "Sunset",
+        "Party",
+        "Fireplace",
+        "Cozy",
+        "Forest",
+        "Pastel Colors",
+        "Wake up",
+        "Bedtime",
+        "Warm White",
+        "Daylight",
+        "Cool white",
+        "Night light",
+        "Focus",
+        "Relax",
+        "True colors",
+        "TV time",
+        "Plantgrowth",
+        "Spring",
+        "Summer",
+        "Fall",
+        "Deepdive",
+        "Jungle",
+        "Mojito",
+        "Club",
+        "Christmas",
+        "Halloween",
+        "Candlelight",
+        "Golden white",
+        "Pulse",
+        "Steampunk",
+        "Rhythm",
+    ]
+
+
+@pytest.mark.asyncio
 async def test_model_description_light_strip(light_strip: wizlight) -> None:
     """Test fetching the model description for a light strip."""
     bulb_type = await light_strip.get_bulbtype()

--- a/pywizlight/tests/test_bulb_missing_kelvin_range.py
+++ b/pywizlight/tests/test_bulb_missing_kelvin_range.py
@@ -1,0 +1,26 @@
+"""Tests for the Bulb API with a light strip."""
+from typing import AsyncGenerator
+
+import pytest
+
+from pywizlight import wizlight
+from pywizlight.tests.fake_bulb import startup_bulb
+from pywizlight.exceptions import WizLightNotKnownBulb
+
+
+@pytest.fixture()
+async def missing_kelvin_range_bulb() -> AsyncGenerator[wizlight, None]:
+    shutdown = startup_bulb(module_name="MISSING_KELVIN", firmware_version="1.16.64")
+    bulb = wizlight(ip="127.0.0.1")
+    yield bulb
+    await bulb.async_close()
+    shutdown()
+
+
+@pytest.mark.asyncio
+async def test_model_description_missing_kelvin_range(
+    missing_kelvin_range_bulb: wizlight,
+) -> None:
+    """Test fetching the model description for a bulb missing the kelvin range."""
+    with pytest.raises(WizLightNotKnownBulb):
+        await missing_kelvin_range_bulb.get_bulbtype()

--- a/pywizlight/tests/test_bulb_no_module_name.py
+++ b/pywizlight/tests/test_bulb_no_module_name.py
@@ -1,0 +1,24 @@
+"""Tests for the Bulb API with a light strip."""
+from typing import AsyncGenerator
+
+import pytest
+
+from pywizlight import wizlight
+from pywizlight.tests.fake_bulb import startup_bulb
+from pywizlight.exceptions import WizLightNotKnownBulb
+
+
+@pytest.fixture()
+async def invalid_module_bulb() -> AsyncGenerator[wizlight, None]:
+    shutdown = startup_bulb(module_name="INVALID", firmware_version="1.16.64")
+    bulb = wizlight(ip="127.0.0.1")
+    yield bulb
+    await bulb.async_close()
+    shutdown()
+
+
+@pytest.mark.asyncio
+async def test_model_description_no_module_bulb(invalid_module_bulb: wizlight) -> None:
+    """Test fetching the model description for a bulb with an invalid module."""
+    with pytest.raises(WizLightNotKnownBulb):
+        await invalid_module_bulb.get_bulbtype()

--- a/pywizlight/tests/test_bulb_rgbtw_1_21_4.py
+++ b/pywizlight/tests/test_bulb_rgbtw_1_21_4.py
@@ -1,4 +1,4 @@
-"""Tests for the Bulb API with a light strip."""
+"""Tests for the Bulb API with a rgbtw bulb."""
 from typing import AsyncGenerator
 
 import pytest
@@ -10,7 +10,7 @@ from pywizlight.tests.fake_bulb import startup_bulb
 
 @pytest.fixture()
 async def dimmable_bulb() -> AsyncGenerator[wizlight, None]:
-    shutdown = startup_bulb(module_name="ESP05_SHDW_21", firmware_version="1.25.0")
+    shutdown = startup_bulb(module_name="ESP20_SHRGBC_01", firmware_version="1.21.4")
     bulb = wizlight(ip="127.0.0.1")
     yield bulb
     await bulb.async_close()
@@ -22,13 +22,13 @@ async def test_model_description_dimmable_bulb(dimmable_bulb: wizlight) -> None:
     """Test fetching the model description dimmable bulb."""
     bulb_type = await dimmable_bulb.get_bulbtype()
     assert bulb_type == BulbType(
-        features=Features(color=False, color_tmp=False, effect=False, brightness=True),
-        name="ESP05_SHDW_21",
-        kelvin_range=KelvinRange(max=2700, min=2700),
-        bulb_type=BulbClass.DW,
-        fw_version="1.25.0",
+        features=Features(color=True, color_tmp=True, effect=True, brightness=True),
+        name="ESP20_SHRGBC_01",
+        kelvin_range=KelvinRange(max=6500, min=2200),
+        bulb_type=BulbClass.RGB,
+        fw_version="1.21.4",
         white_channels=1,
-        white_to_color_ratio=20,
+        white_to_color_ratio=30,
     )
 
 
@@ -36,12 +36,37 @@ async def test_model_description_dimmable_bulb(dimmable_bulb: wizlight) -> None:
 async def test_supported_scenes(dimmable_bulb: wizlight) -> None:
     """Test supported scenes."""
     assert await dimmable_bulb.getSupportedScenes() == [
+        "Ocean",
+        "Romance",
+        "Sunset",
+        "Party",
+        "Fireplace",
+        "Cozy",
+        "Forest",
+        "Pastel Colors",
         "Wake up",
         "Bedtime",
+        "Warm White",
+        "Daylight",
         "Cool white",
         "Night light",
+        "Focus",
+        "Relax",
+        "True colors",
+        "TV time",
+        "Plantgrowth",
+        "Spring",
+        "Summer",
+        "Fall",
+        "Deepdive",
+        "Jungle",
+        "Mojito",
+        "Club",
+        "Christmas",
+        "Halloween",
         "Candlelight",
         "Golden white",
         "Pulse",
         "Steampunk",
+        "Rhythm",
     ]

--- a/pywizlight/tests/test_bulb_rgbtw_1_21_4.py
+++ b/pywizlight/tests/test_bulb_rgbtw_1_21_4.py
@@ -9,7 +9,7 @@ from pywizlight.tests.fake_bulb import startup_bulb
 
 
 @pytest.fixture()
-async def dimmable_bulb() -> AsyncGenerator[wizlight, None]:
+async def rgbtw_bulb() -> AsyncGenerator[wizlight, None]:
     shutdown = startup_bulb(module_name="ESP20_SHRGBC_01", firmware_version="1.21.4")
     bulb = wizlight(ip="127.0.0.1")
     yield bulb
@@ -18,9 +18,9 @@ async def dimmable_bulb() -> AsyncGenerator[wizlight, None]:
 
 
 @pytest.mark.asyncio
-async def test_model_description_dimmable_bulb(dimmable_bulb: wizlight) -> None:
+async def test_model_description_dimmable_bulb(rgbtw_bulb: wizlight) -> None:
     """Test fetching the model description dimmable bulb."""
-    bulb_type = await dimmable_bulb.get_bulbtype()
+    bulb_type = await rgbtw_bulb.get_bulbtype()
     assert bulb_type == BulbType(
         features=Features(color=True, color_tmp=True, effect=True, brightness=True),
         name="ESP20_SHRGBC_01",
@@ -33,9 +33,9 @@ async def test_model_description_dimmable_bulb(dimmable_bulb: wizlight) -> None:
 
 
 @pytest.mark.asyncio
-async def test_supported_scenes(dimmable_bulb: wizlight) -> None:
+async def test_supported_scenes(rgbtw_bulb: wizlight) -> None:
     """Test supported scenes."""
-    assert await dimmable_bulb.getSupportedScenes() == [
+    assert await rgbtw_bulb.getSupportedScenes() == [
         "Ocean",
         "Romance",
         "Sunset",

--- a/pywizlight/tests/test_bulb_socket.py
+++ b/pywizlight/tests/test_bulb_socket.py
@@ -30,3 +30,9 @@ async def test_model_description_socket(socket: wizlight) -> None:
         white_channels=2,
         white_to_color_ratio=20,
     )
+
+
+@pytest.mark.asyncio
+async def test_supported_scenes(socket: wizlight) -> None:
+    """Test supported scenes."""
+    assert await socket.getSupportedScenes() == []

--- a/pywizlight/tests/test_bulb_turnable_white.py
+++ b/pywizlight/tests/test_bulb_turnable_white.py
@@ -9,8 +9,8 @@ from pywizlight.tests.fake_bulb import startup_bulb
 
 
 @pytest.fixture()
-async def dimmable_bulb() -> AsyncGenerator[wizlight, None]:
-    shutdown = startup_bulb(module_name="ESP05_SHDW_21", firmware_version="1.25.0")
+async def turnable_bulb() -> AsyncGenerator[wizlight, None]:
+    shutdown = startup_bulb(module_name="ESP21_SHTW_01", firmware_version="1.25.0")
     bulb = wizlight(ip="127.0.0.1")
     yield bulb
     await bulb.async_close()
@@ -18,14 +18,14 @@ async def dimmable_bulb() -> AsyncGenerator[wizlight, None]:
 
 
 @pytest.mark.asyncio
-async def test_model_description_dimmable_bulb(dimmable_bulb: wizlight) -> None:
+async def test_model_description_dimmable_bulb(turnable_bulb: wizlight) -> None:
     """Test fetching the model description dimmable bulb."""
-    bulb_type = await dimmable_bulb.get_bulbtype()
+    bulb_type = await turnable_bulb.get_bulbtype()
     assert bulb_type == BulbType(
-        features=Features(color=False, color_tmp=False, effect=False, brightness=True),
-        name="ESP05_SHDW_21",
-        kelvin_range=KelvinRange(max=2700, min=2700),
-        bulb_type=BulbClass.DW,
+        features=Features(color=False, color_tmp=True, effect=True, brightness=True),
+        name="ESP21_SHTW_01",
+        kelvin_range=KelvinRange(max=5000, min=2700),
+        bulb_type=BulbClass.TW,
         fw_version="1.25.0",
         white_channels=1,
         white_to_color_ratio=20,
@@ -33,13 +33,19 @@ async def test_model_description_dimmable_bulb(dimmable_bulb: wizlight) -> None:
 
 
 @pytest.mark.asyncio
-async def test_supported_scenes(dimmable_bulb: wizlight) -> None:
+async def test_supported_scenes(turnable_bulb: wizlight) -> None:
     """Test supported scenes."""
-    assert await dimmable_bulb.getSupportedScenes() == [
+    assert await turnable_bulb.getSupportedScenes() == [
+        "Cozy",
         "Wake up",
         "Bedtime",
+        "Warm White",
+        "Daylight",
         "Cool white",
         "Night light",
+        "Focus",
+        "Relax",
+        "TV time",
         "Candlelight",
         "Golden white",
         "Pulse",


### PR DESCRIPTION
- Add coverage for scenes

- Change ValueError to `WizLightNotKnownBulb` since they are thrown for similar cases which supports https://github.com/home-assistant/core/pull/66305
 