### PR TITLE
Implement progressive backoff and improve error reporting

### DIFF
--- a/pywizlight/tests/test_bulb.py
+++ b/pywizlight/tests/test_bulb.py
@@ -39,7 +39,7 @@ async def test_Bulb_Discovery(correct_bulb: wizlight) -> None:
     with patch("pywizlight.discovery.PORT", 0):
         bulbs = await discover_lights(broadcast_space="192.168.178.255", wait_time=0.02)
     for bulb in bulbs:
-        with patch("pywizlight.bulb.SEND_INTERVAL", 0.01), patch(
+        with patch("pywizlight.bulb.FIRST_SEND_INTERVAL", 0.01), patch(
             "pywizlight.bulb.TIMEOUT", 0.01
         ):
             state = await bulb.updateState()
@@ -256,7 +256,7 @@ async def test_get_mac(correct_bulb: wizlight) -> None:
 async def test_timeout(bad_bulb: wizlight) -> None:
     """Test the timout exception after."""
     with pytest.raises(WizLightTimeOutError), patch(
-        "pywizlight.bulb.SEND_INTERVAL", 0.01
+        "pywizlight.bulb.FIRST_SEND_INTERVAL", 0.01
     ), patch("pywizlight.bulb.TIMEOUT", 0.01):
         await bad_bulb.getBulbConfig()
 
@@ -266,7 +266,7 @@ async def test_timeout_PilotBuilder(bad_bulb: wizlight) -> None:
     """Test Timout for Result."""
     # check if the bulb state it given as bool - mock ?
     with pytest.raises(WizLightTimeOutError), patch(
-        "pywizlight.bulb.SEND_INTERVAL", 0.01
+        "pywizlight.bulb.FIRST_SEND_INTERVAL", 0.01
     ), patch("pywizlight.bulb.TIMEOUT", 0.01):
         await bad_bulb.turn_on(PilotBuilder(brightness=255))
 


### PR DESCRIPTION
We needed to wait a little bit longer for the OSError's to come back so we now backoff progressively up to 3s between sends and increases the timeout to 13s since it can take a few more seconds for error to arrive.  This means we now get a much better error when the bulb is offline, and we aren't making a situation where the problem is wifi congestion even worse.

Also since we are using a future, it doesn't matter which udp message the bulb gets and respond to, since as soon as it does, the send task will be canceled and we will declare success.

<img width="281" alt="Screen Shot 2022-02-13 at 09 04 10" src="https://user-images.githubusercontent.com/663432/153759401-f58d3bf5-31f0-46d7-a252-ef6f5bdd9d72.png">
<img width="280" alt="Screen Shot 2022-02-13 at 09 04 04" src="https://user-images.githubusercontent.com/663432/153759403-63081d27-2e12-42e3-bb41-eab1e314c830.png">
