### PR TITLE
Fix missing effects on dimmable white bulbs and add test coverage

### DIFF
--- a/pywizlight/bulblibrary.py
+++ b/pywizlight/bulblibrary.py
@@ -53,8 +53,8 @@ FEATURE_MAP = {
     BulbClass.RGB: Features(brightness=True, color=True, effect=True, color_tmp=True),
     # TODO: TW supports effects but only "some"; improve the mapping to supported effects
     BulbClass.TW: Features(brightness=True, color=False, effect=True, color_tmp=True),
-    # Dimmable white only supports brightness
-    BulbClass.DW: Features(brightness=True, color=False, effect=False, color_tmp=False),
+    # Dimmable white only supports brightness and some basic effects
+    BulbClass.DW: Features(brightness=True, color=False, effect=True, color_tmp=False),
     # Socket supports only on/off
     BulbClass.SOCKET: Features(
         brightness=False, color=False, effect=False, color_tmp=False

--- a/pywizlight/tests/fake_bulb.py
+++ b/pywizlight/tests/fake_bulb.py
@@ -316,6 +316,21 @@ SYSTEM_CONFIGS = {  # AKA getSystemConfig
             "drvConf": [20, 1],
         },
     },
+    ("ESP06_SHDW9_01", "1.11.7"): {
+        "method": "getSystemConfig",
+        "env": "",
+        "result": {
+            "mac": "a8bb509f71d1",
+            "homeId": 0,
+            "homeLock": False,
+            "pairingLock": False,
+            "typeId": 0,
+            "moduleName": "ESP06_SHDW9_01",
+            "fwVersion": "1.11.7",
+            "groupId": 0,
+            "drvConf": [20, 1],
+        },
+    },
 }
 
 USER_CONFIGS = {  # AKA getUserConfig
@@ -389,6 +404,19 @@ USER_CONFIGS = {  # AKA getUserConfig
             "extRange": [2700, 6500],
             "opMode": 0,
             "po": False,
+        },
+    },
+    ("ESP06_SHDW9_01", "1.11.7"): {
+        "method": "getUserConfig",
+        "env": "pro",
+        "result": {
+            "fadeIn": 450,
+            "fadeOut": 500,
+            "fadeNight": False,
+            "dftDim": 100,
+            "pwmRange": [0, 100],
+            "whiteRange": [2700, 6500],
+            "extRange": [2700, 6500],
         },
     },
 }

--- a/pywizlight/tests/fake_bulb.py
+++ b/pywizlight/tests/fake_bulb.py
@@ -300,6 +300,22 @@ SYSTEM_CONFIGS = {  # AKA getSystemConfig
             "drvConf": [20, 2],
         },
     },
+    ("ESP14_SHTW1C_01", "1.18.0"): {
+        "method": "getSystemConfig",
+        "env": "pro",
+        "result": {
+            "mac": "a8bb503ea5f4",
+            "homeId": 5385975,
+            "roomId": 0,
+            "homeLock": False,
+            "pairingLock": False,
+            "typeId": 0,
+            "moduleName": "ESP14_SHTW1C_01",
+            "fwVersion": "1.18.0",
+            "groupId": 0,
+            "drvConf": [20, 1],
+        },
+    },
 }
 
 USER_CONFIGS = {  # AKA getUserConfig
@@ -357,6 +373,21 @@ USER_CONFIGS = {  # AKA getUserConfig
             "pwmRange": [0, 100],
             "whiteRange": [2700, 6500],
             "extRange": [2700, 6500],
+            "po": False,
+        },
+    },
+    ("ESP14_SHTW1C_01", "1.18.0"): {
+        "method": "getUserConfig",
+        "env": "pro",
+        "result": {
+            "fadeIn": 450,
+            "fadeOut": 500,
+            "fadeNight": False,
+            "dftDim": 100,
+            "pwmRange": [0, 100],
+            "whiteRange": [2700, 6500],
+            "extRange": [2700, 6500],
+            "opMode": 0,
             "po": False,
         },
     },

--- a/pywizlight/tests/test_bulb_dimmable_white.py
+++ b/pywizlight/tests/test_bulb_dimmable_white.py
@@ -24,7 +24,7 @@ async def test_model_description_dimmable_bulb(dimmable_bulb: wizlight) -> None:
     """Test fetching the model description dimmable bulb."""
     bulb_type = await dimmable_bulb.get_bulbtype()
     assert bulb_type == BulbType(
-        features=Features(color=False, color_tmp=False, effect=False, brightness=True),
+        features=Features(color=False, color_tmp=False, effect=True, brightness=True),
         name="ESP05_SHDW_21",
         kelvin_range=KelvinRange(max=2700, min=2700),
         bulb_type=BulbClass.DW,

--- a/pywizlight/tests/test_bulb_dimmable_white_1_11_7.py
+++ b/pywizlight/tests/test_bulb_dimmable_white_1_11_7.py
@@ -29,7 +29,7 @@ async def test_model_description_dimmable_bulb(dimmable_bulb: wizlight) -> None:
     """Test fetching the model description dimmable bulb."""
     bulb_type = await dimmable_bulb.get_bulbtype()
     assert bulb_type == BulbType(
-        features=Features(color=False, color_tmp=False, effect=False, brightness=True),
+        features=Features(color=False, color_tmp=False, effect=True, brightness=True),
         name="ESP06_SHDW9_01",
         kelvin_range=KelvinRange(max=6500, min=2700),
         bulb_type=BulbClass.DW,

--- a/pywizlight/tests/test_bulb_dimmable_white_1_11_7.py
+++ b/pywizlight/tests/test_bulb_dimmable_white_1_11_7.py
@@ -1,0 +1,49 @@
+"""Tests for the Bulb API with a light strip."""
+from typing import AsyncGenerator
+
+import pytest
+
+from pywizlight import wizlight
+from pywizlight.bulblibrary import BulbClass, BulbType, Features, KelvinRange
+from pywizlight.tests.fake_bulb import startup_bulb
+
+
+@pytest.fixture()
+async def dimmable_bulb() -> AsyncGenerator[wizlight, None]:
+    shutdown, port = await startup_bulb(
+        module_name="ESP05_SHDW_21", firmware_version="1.25.0"
+    )
+    bulb = wizlight(ip="127.0.0.1", port=port)
+    yield bulb
+    await bulb.async_close()
+    shutdown()
+
+
+@pytest.mark.asyncio
+async def test_model_description_dimmable_bulb(dimmable_bulb: wizlight) -> None:
+    """Test fetching the model description dimmable bulb."""
+    bulb_type = await dimmable_bulb.get_bulbtype()
+    assert bulb_type == BulbType(
+        features=Features(color=False, color_tmp=False, effect=False, brightness=True),
+        name="ESP05_SHDW_21",
+        kelvin_range=KelvinRange(max=2700, min=2700),
+        bulb_type=BulbClass.DW,
+        fw_version="1.25.0",
+        white_channels=1,
+        white_to_color_ratio=20,
+    )
+
+
+@pytest.mark.asyncio
+async def test_supported_scenes(dimmable_bulb: wizlight) -> None:
+    """Test supported scenes."""
+    assert await dimmable_bulb.getSupportedScenes() == [
+        "Wake up",
+        "Bedtime",
+        "Cool white",
+        "Night light",
+        "Candlelight",
+        "Golden white",
+        "Pulse",
+        "Steampunk",
+    ]

--- a/pywizlight/tests/test_bulb_dimmable_white_1_11_7.py
+++ b/pywizlight/tests/test_bulb_dimmable_white_1_11_7.py
@@ -11,12 +11,17 @@ from pywizlight.tests.fake_bulb import startup_bulb
 @pytest.fixture()
 async def dimmable_bulb() -> AsyncGenerator[wizlight, None]:
     shutdown, port = await startup_bulb(
-        module_name="ESP05_SHDW_21", firmware_version="1.25.0"
+        module_name="ESP06_SHDW9_01", firmware_version="1.11.7"
     )
     bulb = wizlight(ip="127.0.0.1", port=port)
     yield bulb
     await bulb.async_close()
     shutdown()
+
+
+# These have a cnx value in the response. Unknown what it means
+# {"method":"getPilot","env":"pro","result":{"mac":"a8bb509f71d1","rssi":-54,"cnx":"0000","src":"","state":true,"sceneId":0,"temp":2700,"dimming":100}}
+# {"method":"syncPilot","id":25,"env":"pro","params":{"mac":"a8bb509f71d1","rssi":-55,"cnx":"0000","src":"udp","state":true,"sceneId":0,"temp":2700,"dimming":100}}
 
 
 @pytest.mark.asyncio
@@ -32,18 +37,3 @@ async def test_model_description_dimmable_bulb(dimmable_bulb: wizlight) -> None:
         white_channels=1,
         white_to_color_ratio=20,
     )
-
-
-@pytest.mark.asyncio
-async def test_supported_scenes(dimmable_bulb: wizlight) -> None:
-    """Test supported scenes."""
-    assert await dimmable_bulb.getSupportedScenes() == [
-        "Wake up",
-        "Bedtime",
-        "Cool white",
-        "Night light",
-        "Candlelight",
-        "Golden white",
-        "Pulse",
-        "Steampunk",
-    ]

--- a/pywizlight/tests/test_bulb_dimmable_white_1_11_7.py
+++ b/pywizlight/tests/test_bulb_dimmable_white_1_11_7.py
@@ -30,10 +30,10 @@ async def test_model_description_dimmable_bulb(dimmable_bulb: wizlight) -> None:
     bulb_type = await dimmable_bulb.get_bulbtype()
     assert bulb_type == BulbType(
         features=Features(color=False, color_tmp=False, effect=False, brightness=True),
-        name="ESP05_SHDW_21",
-        kelvin_range=KelvinRange(max=2700, min=2700),
+        name="ESP06_SHDW9_01",
+        kelvin_range=KelvinRange(max=6500, min=2700),
         bulb_type=BulbClass.DW,
-        fw_version="1.25.0",
+        fw_version="1.11.7",
         white_channels=1,
         white_to_color_ratio=20,
     )

--- a/pywizlight/tests/test_bulb_turnable_white_1_18_0.py
+++ b/pywizlight/tests/test_bulb_turnable_white_1_18_0.py
@@ -1,0 +1,34 @@
+"""Tests for the Bulb API with a light strip."""
+from typing import AsyncGenerator
+
+import pytest
+
+from pywizlight import wizlight
+from pywizlight.bulblibrary import BulbClass, BulbType, Features, KelvinRange
+from pywizlight.tests.fake_bulb import startup_bulb
+
+
+@pytest.fixture()
+async def turnable_bulb() -> AsyncGenerator[wizlight, None]:
+    shutdown, port = await startup_bulb(
+        module_name="ESP14_SHTW1C_01", firmware_version="1.18.0"
+    )
+    bulb = wizlight(ip="127.0.0.1", port=port)
+    yield bulb
+    await bulb.async_close()
+    shutdown()
+
+
+@pytest.mark.asyncio
+async def test_model_description_dimmable_bulb(turnable_bulb: wizlight) -> None:
+    """Test fetching the model description dimmable bulb."""
+    bulb_type = await turnable_bulb.get_bulbtype()
+    assert bulb_type == BulbType(
+        features=Features(color=False, color_tmp=True, effect=True, brightness=True),
+        name="ESP14_SHTW1C_01",
+        kelvin_range=KelvinRange(max=6500, min=2700),
+        bulb_type=BulbClass.TW,
+        fw_version="1.18.0",
+        white_channels=1,
+        white_to_color_ratio=20,
+    )

--- a/pywizlight/tests/test_push_manager.py
+++ b/pywizlight/tests/test_push_manager.py
@@ -93,7 +93,9 @@ async def test_push_updates(socket_push: wizlight) -> None:
 
 
 @pytest.mark.asyncio
-async def test_discovery_by_firstbeat(socket_push: wizlight) -> None:
+async def test_discovery_by_firstbeat(
+    socket_push: wizlight, caplog: pytest.LogCaptureFixture
+) -> None:
     """Test discovery from first beat."""
     bulb_type = await socket_push.get_bulbtype()
     assert bulb_type == BulbType(
@@ -131,6 +133,10 @@ async def test_discovery_by_firstbeat(socket_push: wizlight) -> None:
         ("127.0.0.1", push_port),
     )
     push_transport.sendto(
+        b"GARBAGE",
+        ("127.0.0.1", push_port),
+    )
+    push_transport.sendto(
         to_wiz_json(
             {
                 "method": "firstBeat",
@@ -144,3 +150,4 @@ async def test_discovery_by_firstbeat(socket_push: wizlight) -> None:
     assert last_discovery is not None
     assert last_discovery == DiscoveredBulb("127.0.0.1", socket_push.mac)
     push_transport.close()
+    assert "GARBAGE" in caplog.text


### PR DESCRIPTION
~~So far nothing has broken with the older devices I have been receiving from ebay~~.   Effects are missing from dimmable white bulbs

I'm adding the output to the tests though so if we do change something or add support for a new thing in the future we will know if we broke old firmware compat.