### PR TITLE
Add wizlight examples to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,6 +193,25 @@ Commands:
   state     Get the current state from the given bulb.
 ```
 
+### Examples
+
+```
+$ wizlight discover --b 192.168.0.101
+Search for bulbs in 192.168.0.101 ...
+{'ip_address': '192.168.0.101', 'mac_address': 'a8bs4090193d'}
+
+$ wizlight on --ip 192.168.0.101 --k 3000 --brightness 128
+Turning on 192.168.0.101
+
+$ wizlight off --ip 192.168.0.101
+Turning off 192.168.0.101
+
+$ wizlight state --ip 192.168.0.101
+{'mac': 'a8bs4090193d', 'rssi': -57, 'src': '', 'state': False, 'sceneId': 0, 'temp': 3000, 'dimming': 50}
+```
+
+Run `wizlight COMMAND --help` to see usage and options.
+
 ## Discovery
 
 The discovery works with a UDP Broadcast request and collects all bulbs in the network.

--- a/README.md
+++ b/README.md
@@ -187,10 +187,11 @@ Options:
   --help     Show this message and exit.
 
 Commands:
-  discover  Discover bulb in the local network.
-  off       Turn the bulb off.
-  on        Turn the bulb on.
-  state     Get the current state from the given bulb.
+  discover   Discover bulb in the local network.
+  off        Turn the bulb off.
+  on         Turn the bulb on.
+  set-state  Set the current state of a given bulb.
+  state      Get the current state from the given bulb.
 ```
 
 ### Examples

--- a/pywizlight/cli.py
+++ b/pywizlight/cli.py
@@ -35,7 +35,7 @@ def main() -> None:
     help="Define the broadcast address like 192.168.1.255.",
 )
 async def discover(b: str) -> None:
-    """Discovery bulb in the local network."""
+    """Discover bulb in the local network."""
     click.echo(f"Search for bulbs in {b} ... ")
 
     bulbs = await discovery.find_wizlights(broadcast_address=b)


### PR DESCRIPTION
It's not clear from running `wizlight --help` what additional command options exist, or that it can be used non-interactively in scripts.
See https://github.com/rgomezjnr/wizcon/issues/8