### PR TITLE
Fix broken pytest on github actions

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -43,7 +43,7 @@ jobs:
 
       - name: Test with pytest
         run: |
-            pytest --durations=0 --cov=pywizlight --cov-report term-missing --cov-report xml
+            pytest --asyncio-mode=auto --durations=0 --cov=pywizlight --cov-report term-missing --cov-report xml
 
       - name: Upload codecov
         uses: codecov/codecov-action@v2

--- a/pywizlight/push_manager.py
+++ b/pywizlight/push_manager.py
@@ -15,7 +15,6 @@ LISTEN_PORT = 38900
 
 
 class PushManager:
-
     _manager = None
 
     @classmethod


### PR DESCRIPTION
Hi, first time contributing to open-source project here sorry if I do anything wrong.

# Issue
Version [0.19.0](https://pytest-asyncio.readthedocs.io/en/latest/reference/changelog.html#id11) of pytest-asyncio introduced a breaking change to the default asyncio mode. It changed the mode to strict which broke the pytest pipeline. 

`BREAKING: The default asyncio_mode is now strict.`

# Fix
To fix it, we set asyncio_mode to auto when running pytest on github actions. This fixes the pipeline on my master branch.

Hope this helps.
