### PR TITLE
Fix a race condition in bulb.py when closing while a bulb is offline

### DIFF
--- a/pywizlight/bulb.py
+++ b/pywizlight/bulb.py
@@ -376,7 +376,7 @@ async def _send_udp_message_with_retry(
     send_wait = FIRST_SEND_INTERVAL
     total_waited = 0.0
     for send in range(MAX_SEND_DATAGRAMS):
-        if transport.is_closing() or response_future.done():
+        if transport is None or transport.is_closing() or response_future.done():
             return
         attempt = send + 1
         _LOGGER.debug(


### PR DESCRIPTION
When restarting Home Assistant, an error is thrown when bulbs are offline.

Traceback (most recent call last):
  File "/usr/local/lib/python3.11/site-packages/pywizlight/bulb.py", line 379, in _send_udp_message_with_retry
    if transport.is_closing() or response_future.done():
       ^^^^^^^^^^^^^^^^^^^^
AttributeError: 'NoneType' object has no attribute 'is_closing'