### PR TITLE
Use the IP address resolved by the transport

### DIFF
--- a/pywizlight/bulb.py
+++ b/pywizlight/bulb.py
@@ -484,6 +484,12 @@ class wizlight:
         self.transport = cast(asyncio.DatagramTransport, transport_proto[0])
         self.protocol = cast(WizProtocol, transport_proto[1])
 
+        # The transport expects us to send to the same address we connected to here
+        ip, port = self.transport.get_extra_info("peername")
+        if (self.ip, self.port) != (ip, port):
+            _LOGGER.debug("Resolved %s:%s to %s:%s", self.ip, self.port, ip, port)
+            self.ip, self.port = ip, port
+
     def register(self) -> None:
         """Call register to keep alive push updates."""
         if self.push_running:


### PR DESCRIPTION
Hostname destination support fails because asyncio's DatagramTransport internally resolves hostnames to IP addresses and expects any call to sendto() to use that IP instead of the input hostname.

This commit recognizes that resolution may have happened and updates self.ip and self.port to match the resolved address.