### PR TITLE
Remove snowy sky

### DIFF
--- a/pywizlight/scenes.py
+++ b/pywizlight/scenes.py
@@ -30,7 +30,7 @@ SCENES = {
     8: "Pastel colors",
     2: "Romance",
     16: "Relax",
-    #36: "Snowy sky",
+    # 36: "Snowy sky",
     3: "Sunset",
     20: "Spring",
     21: "Summer",

--- a/pywizlight/scenes.py
+++ b/pywizlight/scenes.py
@@ -30,7 +30,7 @@ SCENES = {
     8: "Pastel colors",
     2: "Romance",
     16: "Relax",
-    36: "Snowy sky",
+    #36: "Snowy sky",
     3: "Sunset",
     20: "Spring",
     21: "Summer",

--- a/pywizlight/tests/test_bulb_light_strip_1_25_0.py
+++ b/pywizlight/tests/test_bulb_light_strip_1_25_0.py
@@ -56,7 +56,7 @@ async def test_supported_scenes(light_strip: wizlight) -> None:
         "Pastel colors",
         "Romance",
         "Relax",
-        "Snowy sky",
+        #"Snowy sky",
         "Sunset",
         "Spring",
         "Summer",

--- a/pywizlight/tests/test_bulb_light_strip_1_25_0.py
+++ b/pywizlight/tests/test_bulb_light_strip_1_25_0.py
@@ -56,7 +56,7 @@ async def test_supported_scenes(light_strip: wizlight) -> None:
         "Pastel colors",
         "Romance",
         "Relax",
-        #"Snowy sky",
+        # "Snowy sky",
         "Sunset",
         "Spring",
         "Summer",

--- a/pywizlight/tests/test_bulb_rgbw_1_21_4.py
+++ b/pywizlight/tests/test_bulb_rgbw_1_21_4.py
@@ -65,7 +65,7 @@ async def test_supported_scenes(rgbw_bulb: wizlight) -> None:
         "Pastel colors",
         "Romance",
         "Relax",
-        #"Snowy sky",
+        # "Snowy sky",
         "Sunset",
         "Spring",
         "Summer",

--- a/pywizlight/tests/test_bulb_rgbw_1_21_4.py
+++ b/pywizlight/tests/test_bulb_rgbw_1_21_4.py
@@ -65,7 +65,7 @@ async def test_supported_scenes(rgbw_bulb: wizlight) -> None:
         "Pastel colors",
         "Romance",
         "Relax",
-        "Snowy sky",
+        #"Snowy sky",
         "Sunset",
         "Spring",
         "Summer",


### PR DESCRIPTION
- "Sony sky" seems not a common scene for RGB bulbs
- Setting it with an unsupported device will cause an unstable state of the bulb -> removed for now