### PR TITLE
Fix dual-head state updates

### DIFF
--- a/pywizlight/bulb.py
+++ b/pywizlight/bulb.py
@@ -92,6 +92,13 @@ def states_match(old: Dict[str, Any], new: Dict[str, Any]) -> bool:
     return True
 
 
+def _dual_head_state_index(device: Any) -> Optional[int]:
+    """Convert a WiZ dual-head device number to a state list index."""
+    if isinstance(device, int) and not isinstance(device, bool) and 1 <= device <= 2:
+        return device - 1
+    return None
+
+
 def _rgb_in_range_or_raise(rgb: Tuple[Union[float, int], ...]) -> None:
     if not (0 <= rgb[0] < 256):
         raise ValueError("Red is not in range between 0-255.")
@@ -655,19 +662,47 @@ class wizlight:
     def _on_push(self, resp: dict, addr: Tuple[str, int]) -> None:
         """Handle a syncPilot from the device."""
         self.history.message(HISTORY_PUSH, resp)
+        new_state = resp["params"]
+        if self.bulbtype and self.bulbtype.features.dual_head:
+            state_index = _dual_head_state_index(new_state.get("devices"))
+            is_zoned = len(self.state) > 1
+            current_state = self.state[0] if self.state else None
+            is_ratio = not is_zoned and (
+                new_state.get("ratio") is not None
+                or (current_state is not None and current_state.get_ratio() is not None)
+            )
+            if is_ratio:
+                self.last_push = time.monotonic()
+                old_state = current_state.pilotResult if current_state else None
+                if old_state and states_match(old_state, new_state):
+                    return
+                self.state = [PilotParser(new_state)]
+                if self.push_callback:
+                    self.push_callback(self.state)
+                return
+            if state_index is not None:
+                self.last_push = time.monotonic()
+                while len(self.state) < 2:
+                    self.state.append(None)
+                old_head_state = self.state[state_index]
+                old_state = old_head_state.pilotResult if old_head_state else None
+                if old_state and states_match(old_state, new_state):
+                    return
+                self.state[state_index] = PilotParser(new_state)
+                if self.push_callback:
+                    self.push_callback(self.state)
+                return
+            if is_zoned:
+                _LOGGER.debug(
+                    "%s: Ignoring dual-head push without a valid devices index",
+                    self.ip,
+                )
+                return
+
         self.last_push = time.monotonic()
         old_state = self.state[0].pilotResult if self.state and self.state[0] else None
-        new_state = resp["params"]
         if old_state and states_match(old_state, new_state):
             return
-        if self.bulbtype and self.bulbtype.features.dual_head:
-            # For dual head, push updates might be partial or ambiguous.
-            # We avoid corrupting the list-based state and force a refresh.
-            self.last_push = 0
-            if self.push_callback:
-                self.push_callback(self.state)
-            return
-
         self.state = [PilotParser(new_state)]
         if self.push_callback:
             self.push_callback(self.state)
@@ -899,27 +934,68 @@ class wizlight:
         """
 
         if self.last_push + MAX_TIME_BETWEEN_PUSH < time.monotonic():
+            last_push_before_poll = self.last_push
             if self.bulbtype is None:
                 await self.get_bulbtype()
+                if self.last_push != last_push_before_poll:
+                    return self.state
 
-            new_state: List[Optional[PilotParser]] = []
-            if self.bulbtype and self.bulbtype.features.dual_head:
-                for heads in range(2):
-                    method = {"method": "getPilot", "params": {"devices": heads}}
-                    resp = await self.send(method)
-                    if resp is not None and "result" in resp:
-                        head_state = PilotParser(resp["result"])
-                    else:
-                        head_state = None
-                    new_state.append(head_state)
-            # Without heads
+            resp = await self.send({"method": "getPilot", "params": {}})
+            if self.last_push != last_push_before_poll:
+                return self.state
+            if resp is not None and "result" in resp:
+                state = PilotParser(resp["result"])
             else:
-                resp = await self.send({"method": "getPilot", "params": {}})
-                if resp is not None and "result" in resp:
-                    single_state = PilotParser(resp["result"])
-                else:
-                    single_state = None
-                new_state.append(single_state)
+                state = None
+
+            if not self.bulbtype or not self.bulbtype.features.dual_head:
+                self.state = [state]
+                return self.state
+
+            is_zoned = len(self.state) > 1
+            current_state = self.state[0] if len(self.state) == 1 else None
+            current_state_is_ratio = (
+                current_state is not None and current_state.get_ratio() is not None
+            )
+            if not is_zoned and (
+                (state is not None and state.get_ratio() is not None)
+                or (state is None and current_state_is_ratio)
+            ):
+                self.state = [state]
+                return self.state
+
+            new_state: List[Optional[PilotParser]] = (
+                self.state[:2] if is_zoned else [None, None]
+            )
+            while len(new_state) < 2:
+                new_state.append(None)
+            existing_first_index = (
+                _dual_head_state_index(new_state[0].pilotResult.get("devices"))
+                if new_state[0]
+                else None
+            )
+            if state is not None and existing_first_index is None:
+                new_state[0] = state
+
+            for state_index in range(2):
+                try:
+                    indexed_resp = await self.send(
+                        {"method": "getPilot", "params": {"devices": state_index}}
+                    )
+                except (WizLightConnectionError, WizLightTimeOutError):
+                    if self.last_push != last_push_before_poll:
+                        return self.state
+                    break
+                if self.last_push != last_push_before_poll:
+                    return self.state
+                indexed_result = (
+                    indexed_resp.get("result") if indexed_resp is not None else None
+                )
+                if not isinstance(indexed_result, dict):
+                    continue
+                indexed_state = PilotParser(indexed_result)
+                if _dual_head_state_index(indexed_result.get("devices")) == state_index:
+                    new_state[state_index] = indexed_state
             self.state = new_state
         return self.state
 

--- a/pywizlight/tests/test_bulb_rgbww_dual.py
+++ b/pywizlight/tests/test_bulb_rgbww_dual.py
@@ -1,11 +1,14 @@
 """Tests for the Bulb API."""
 
-from typing import AsyncGenerator
+from typing import AsyncGenerator, List, Optional
+from unittest.mock import AsyncMock, call, patch
 
 import pytest
 
 from pywizlight import wizlight
+from pywizlight.bulb import PilotParser
 from pywizlight.bulblibrary import BulbClass, BulbType, Features, KelvinRange
+from pywizlight.exceptions import WizLightConnectionError
 from pywizlight.tests.fake_bulb import startup_bulb
 
 
@@ -35,3 +38,225 @@ async def test_model_description_rgbww_bulb(rgbww_bulb: wizlight) -> None:
         white_channels=2,
         white_to_color_ratio=20,
     )
+
+
+@pytest.mark.asyncio
+async def test_dual_head_state_is_seeded_by_plain_get_pilot(
+    rgbww_bulb: wizlight,
+) -> None:
+    """Test a plain getPilot seeds zoned state until pushes arrive."""
+    states = await rgbww_bulb.updateState()
+
+    assert states is not None
+    assert len(states) == 2
+    assert states[0] is not None
+    assert states[1] is None
+
+
+@pytest.mark.asyncio
+async def test_dual_head_state_uses_strict_indexed_responses(
+    rgbww_bulb: wizlight,
+) -> None:
+    """Test indexed responses map their 1-based tags to state slots."""
+    await rgbww_bulb.get_bulbtype()
+    plain = {"state": True, "dimming": 50}
+    zone_a = {"devices": 1, "state": True, "dimming": 25}
+    zone_b = {"devices": 2, "state": False, "dimming": 75}
+    send = AsyncMock(
+        side_effect=[
+            {"method": "getPilot", "result": plain},
+            {"method": "getPilot", "result": zone_a},
+            {"method": "getPilot", "result": zone_b},
+        ]
+    )
+
+    with patch.object(rgbww_bulb, "send", send):
+        states = await rgbww_bulb.updateState()
+
+    assert states is not None
+    assert [state.pilotResult if state else None for state in states] == [
+        zone_a,
+        zone_b,
+    ]
+    assert send.call_args_list == [
+        call({"method": "getPilot", "params": {}}),
+        call({"method": "getPilot", "params": {"devices": 0}}),
+        call({"method": "getPilot", "params": {"devices": 1}}),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_dual_head_state_ignores_untagged_indexed_responses(
+    rgbww_bulb: wizlight,
+) -> None:
+    """Test ignored selectors do not fabricate duplicate zone states."""
+    await rgbww_bulb.get_bulbtype()
+    plain = {"state": True, "dimming": 50}
+    send = AsyncMock(
+        side_effect=[
+            {"method": "getPilot", "result": plain},
+            {"method": "getPilot", "result": plain},
+            {"method": "getPilot", "result": {**plain, "devices": 1}},
+        ]
+    )
+
+    with patch.object(rgbww_bulb, "send", send):
+        states = await rgbww_bulb.updateState()
+
+    assert states is not None
+    assert states[0] is not None
+    assert states[0].pilotResult == plain
+    assert states[1] is None
+
+
+@pytest.mark.asyncio
+async def test_dual_head_state_keeps_partial_indexed_result_on_error(
+    rgbww_bulb: wizlight,
+) -> None:
+    """Test an accepted head survives a later indexed request failure."""
+    await rgbww_bulb.get_bulbtype()
+    plain = {"state": True, "dimming": 50}
+    zone_a = {"devices": 1, "state": True, "dimming": 25}
+    send = AsyncMock(
+        side_effect=[
+            {"method": "getPilot", "result": plain},
+            {"method": "getPilot", "result": zone_a},
+            WizLightConnectionError("Invalid params"),
+        ]
+    )
+
+    with patch.object(rgbww_bulb, "send", send):
+        states = await rgbww_bulb.updateState()
+
+    assert states is not None
+    assert states[0] is not None
+    assert states[0].pilotResult == zone_a
+    assert states[1] is None
+
+
+@pytest.mark.asyncio
+async def test_dual_head_state_retries_indexed_polling_after_error(
+    rgbww_bulb: wizlight,
+) -> None:
+    """Test an indexed request failure is retried on the next stale poll."""
+    await rgbww_bulb.get_bulbtype()
+    plain = {"state": True, "dimming": 50}
+    send = AsyncMock(
+        side_effect=[
+            {"method": "getPilot", "result": plain},
+            WizLightConnectionError("Invalid params"),
+            {"method": "getPilot", "result": plain},
+            WizLightConnectionError("Invalid params"),
+        ]
+    )
+
+    with patch.object(rgbww_bulb, "send", send):
+        await rgbww_bulb.updateState()
+        await rgbww_bulb.updateState()
+
+    assert send.call_args_list == [
+        call({"method": "getPilot", "params": {}}),
+        call({"method": "getPilot", "params": {"devices": 0}}),
+        call({"method": "getPilot", "params": {}}),
+        call({"method": "getPilot", "params": {"devices": 0}}),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_dual_head_pushes_update_individual_states(
+    rgbww_bulb: wizlight,
+) -> None:
+    """Test indexed syncPilot pushes update only their corresponding head."""
+    await rgbww_bulb.updateState()
+    callbacks: List[List[Optional[PilotParser]]] = []
+    rgbww_bulb.push_callback = lambda states: callbacks.append(states.copy())
+    zone_a = {"devices": 1, "state": True, "dimming": 25}
+    zone_b = {"devices": 2, "state": False, "dimming": 75}
+
+    rgbww_bulb._on_push({"method": "syncPilot", "params": zone_a}, ("127.0.0.1", 38899))
+    rgbww_bulb._on_push({"method": "syncPilot", "params": zone_b}, ("127.0.0.1", 38899))
+
+    assert rgbww_bulb.state[0] is not None
+    assert rgbww_bulb.state[0].pilotResult == zone_a
+    assert rgbww_bulb.state[1] is not None
+    assert rgbww_bulb.state[1].pilotResult == zone_b
+    assert len(callbacks) == 2
+
+    rgbww_bulb.last_push = 0
+    rgbww_bulb._on_push({"method": "syncPilot", "params": zone_b}, ("127.0.0.1", 38899))
+    assert len(callbacks) == 2
+    assert rgbww_bulb.last_push > 0
+
+
+@pytest.mark.asyncio
+async def test_dual_head_push_without_index_does_not_replace_zoned_state(
+    rgbww_bulb: wizlight,
+) -> None:
+    """Test an ambiguous push does not collapse an established zoned state."""
+    await rgbww_bulb.updateState()
+    zone_a = {"devices": 1, "state": True}
+    zone_b = {"devices": 2, "state": False}
+    rgbww_bulb._on_push({"method": "syncPilot", "params": zone_a}, ("127.0.0.1", 38899))
+    rgbww_bulb._on_push({"method": "syncPilot", "params": zone_b}, ("127.0.0.1", 38899))
+
+    rgbww_bulb._on_push(
+        {"method": "syncPilot", "params": {"state": False}},
+        ("127.0.0.1", 38899),
+    )
+
+    assert rgbww_bulb.state[0] is not None
+    assert rgbww_bulb.state[0].pilotResult == zone_a
+    assert rgbww_bulb.state[1] is not None
+    assert rgbww_bulb.state[1].pilotResult == zone_b
+
+    rgbww_bulb.last_push = 0
+    rgbww_bulb._on_push(
+        {"method": "syncPilot", "params": {"state": True}},
+        ("127.0.0.1", 38899),
+    )
+    assert rgbww_bulb.last_push == 0
+
+
+@pytest.mark.asyncio
+async def test_dual_head_poll_preserves_push_state(rgbww_bulb: wizlight) -> None:
+    """Test polling does not discard per-head state learned from pushes."""
+    await rgbww_bulb.updateState()
+    zone_a = {"devices": 1, "state": True}
+    zone_b = {"devices": 2, "state": False}
+    rgbww_bulb._on_push({"method": "syncPilot", "params": zone_a}, ("127.0.0.1", 38899))
+    rgbww_bulb._on_push({"method": "syncPilot", "params": zone_b}, ("127.0.0.1", 38899))
+    rgbww_bulb.last_push = 0
+
+    states = await rgbww_bulb.updateState()
+
+    assert states is not None
+    assert states[0] is not None
+    assert states[0].pilotResult == zone_a
+    assert states[1] is not None
+    assert states[1].pilotResult == zone_b
+
+
+@pytest.mark.asyncio
+async def test_dual_head_push_during_poll_wins(rgbww_bulb: wizlight) -> None:
+    """Test a push received during polling is not overwritten."""
+    await rgbww_bulb.updateState()
+    rgbww_bulb.last_push = 0
+    original_send = rgbww_bulb.send
+    zone_b = {"devices": 2, "state": True}
+
+    async def send_with_push(message: dict) -> dict:
+        response = await original_send(message)
+        if message["params"].get("devices") == 0:
+            rgbww_bulb._on_push(
+                {"method": "syncPilot", "params": zone_b},
+                ("127.0.0.1", 38899),
+            )
+            raise WizLightConnectionError("Invalid params")
+        return response
+
+    with patch.object(rgbww_bulb, "send", side_effect=send_with_push):
+        states = await rgbww_bulb.updateState()
+
+    assert states is not None
+    assert states[1] is not None
+    assert states[1].pilotResult == zone_b

--- a/pywizlight/tests/test_bulb_squire_1_21_40.py
+++ b/pywizlight/tests/test_bulb_squire_1_21_40.py
@@ -1,6 +1,7 @@
 """Tests for the Bulb API with a Squire."""
 
 from typing import AsyncGenerator
+from unittest.mock import call, patch
 
 import pytest
 
@@ -25,12 +26,31 @@ async def test_setting_ratio(squire: wizlight) -> None:
     """Test setting ratio."""
     await squire.set_ratio(50)
     states = await squire.updateState()
+    assert states is not None and len(states) == 1
     assert states and states[0] and states[0].get_ratio() == 50
     await squire.turn_on(PilotBuilder(ratio=20))
     states = await squire.updateState()
     assert states and states[0] and states[0].get_ratio() == 20
     with pytest.raises(ValueError):
         await squire.set_ratio(500)
+
+
+@pytest.mark.asyncio
+async def test_ratio_push_remains_single_state(squire: wizlight) -> None:
+    """Test a ratio-based dual-head push updates one combined state."""
+    await squire.get_bulbtype()
+    await squire.set_ratio(50)
+    with patch.object(squire, "send", wraps=squire.send) as send:
+        await squire.updateState()
+
+    assert send.call_args_list == [call({"method": "getPilot", "params": {}})]
+    push_state = {"devices": 2, "state": True, "ratio": 75}
+
+    squire._on_push({"method": "syncPilot", "params": push_state}, ("127.0.0.1", 38899))
+
+    assert len(squire.state) == 1
+    assert squire.state[0] is not None
+    assert squire.state[0].pilotResult == push_state
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Fixes dual-head state updates across firmware variants:

- keeps ratio-based lights as a single state
- validates indexed `getPilot` responses before populating per-head state
- falls back to tagged `syncPilot` updates when indexed polling is unavailable
- preserves per-head push state across polling and concurrent updates

Verified with a HALO and Squire on firmware 1.38.0, plus captured Mobile ratio behavior from firmware 1.29.1. All 89 tests pass.

This unblocks https://github.com/home-assistant/core/pull/177502.
